### PR TITLE
chore: gitignore wrangler local dev state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ logs
 .fleet
 .idea
 
+# Wrangler local dev state
+.wrangler
+
 # Local env files
 .env
 .env.*

--- a/.wrangler/deploy/config.json
+++ b/.wrangler/deploy/config.json
@@ -1,1 +1,0 @@
-{"configPath":"../../.output/server/wrangler.json"}


### PR DESCRIPTION
.wrangler/deploy/config.json was being tracked, causing noisy diffs from wrangler's local dev/deploy state on every run. Untrack it and ignore .wrangler/ going forward.