### PR TITLE
refactor(score calc): group score context into mode/arena/mjolnirStrike

### DIFF
--- a/components/ScoreCalc/UnitCard.vue
+++ b/components/ScoreCalc/UnitCard.vue
@@ -465,7 +465,7 @@ import {
   SCU_CODE_PREFIX,
   DUEL_SKILL_IDS_BY_MOVE_BY_COLOR,
   type IUnitInstanceInScoreCalc,
-  type ScoreContext,
+  type ScoreContextOut,
 } from '~/utils/types/score-calc'
 import { getEmptyUnitInstanceSkillIds } from '~/utils/types/units'
 // import { STATS } from '~/utils/types/units-stats'
@@ -497,7 +497,7 @@ const emit = defineEmits([
 ])
 const props = withDefaults(
   defineProps<{
-    scoreContext: ScoreContext
+    scoreContext: ScoreContextOut
     unitInstance: IUnitInstanceInScoreCalc
     index: number
     isLoading?: boolean

--- a/composables/useScoreContext.ts
+++ b/composables/useScoreContext.ts
@@ -3,37 +3,45 @@ import filter from 'lodash-es/filter'
 import { objectFromEntries } from '~/utils/functions/typeSafe'
 import type {
   IUnitInstanceInScoreCalc,
-  ScoreContext,
+  ScoreContextIn,
+  ScoreContextOut,
 } from '~/utils/types/score-calc'
-import { SORTED_LEGENDARY_ELEMENTS, type Element } from '~/utils/types/elements'
+import { SORTED_LEGENDARY_ELEMENTS } from '~/utils/types/elements'
 
 export default function useScoreContext(
   units: Ref<IUnitInstanceInScoreCalc[]>,
-  hasBonusUnit: Ref<boolean>,
-  seasonElements: Ref<Element[]>,
-  mjolnirStrike?: Ref<ScoreContext['mjolnirStrike']>,
+  arena?: Ref<ScoreContextIn['arena']>,
+  mjolnirStrike?: Ref<ScoreContextIn['mjolnirStrike']>,
 ) {
   const storeDataUnits = useStoreDataUnits()
 
-  return computed<ScoreContext>(() => ({
-    bonusFactor: hasBonusUnit.value || mjolnirStrike?.value?.isActive ? 2 : 1,
-    seasonElements: seasonElements.value,
-    legendaryCounts: objectFromEntries(
-      SORTED_LEGENDARY_ELEMENTS.map((element) => [
-        element,
-        filter(units.value, (u) => {
-          if (!u.id) return false
+  return computed<ScoreContextOut>(() => ({
+    bonusFactor:
+      arena?.value?.hasBonusUnit || mjolnirStrike?.value?.isActive ? 2 : 1,
+    arena: {
+      ...(arena?.value ?? {
+        isActive: false,
+        hasBonusUnit: false,
+        seasons: [],
+      }),
+      legendaryCounts: objectFromEntries(
+        SORTED_LEGENDARY_ELEMENTS.map((element) => [
+          element,
+          filter(units.value, (u) => {
+            if (!u.id) return false
 
-          const unit = storeDataUnits.unitsById[u.id]
-          if (!unit) return false
-          if (!unit.is_legendary) return false
+            const unit = storeDataUnits.unitsById[u.id]
+            if (!unit) return false
+            if (!unit.is_legendary) return false
 
-          return unit.element === element
-        }).length,
-      ]),
-    ),
+            return unit.element === element
+          }).length,
+        ]),
+      ),
+    },
     mjolnirStrike: mjolnirStrike?.value ?? {
       isActive: false,
+      tier: null,
       major: null,
       minor: null,
     },

--- a/composables/useUnitScore.ts
+++ b/composables/useUnitScore.ts
@@ -18,7 +18,7 @@ import {
   GROWTH_RATE_DIFF,
   getEmptyUnitInstanceSkillSPs,
   type IUnitInstanceInScoreCalc,
-  type ScoreContext,
+  type ScoreContextOut,
 } from '~/utils/types/score-calc'
 import { SKILL_PASSIVE_A } from '~/utils/types/skills'
 import { BANE, BOON, STATS } from '~/utils/types/units-stats'
@@ -39,7 +39,7 @@ const statAtLevel = (
 
 export default function useUnitScore(
   unitInstance: Ref<IUnitInstanceInScoreCalc>,
-  scoreContext: Ref<ScoreContext>,
+  scoreContext: Ref<ScoreContextOut>,
   isAttachedChosenHero: boolean = false,
 ) {
   const storeDataUnits = useStoreDataUnits()
@@ -74,7 +74,7 @@ export default function useUnitScore(
     const element = unit.value.element
     if (!element) return false
 
-    return scoreContext.value.seasonElements.includes(element)
+    return scoreContext.value.arena.seasons.includes(element)
   })
 
   const rarityConstants = computed(
@@ -237,7 +237,7 @@ export default function useUnitScore(
   const bonusMergesCount = computed(() => {
     if (!unit.value) return 0
     if (!unit.value.is_mythic) return 0
-    if (!scoreContext.value.mjolnirStrike.isActive) return 0
+    if (scoreContext.value.arena.isActive) return 0
 
     if (unit.value.element === scoreContext.value.mjolnirStrike.major) return 10
     if (unit.value.element === scoreContext.value.mjolnirStrike.minor) return 5
@@ -270,12 +270,12 @@ export default function useUnitScore(
             chosenHeroIsInSeason.value ? chosenHero.value?.element : null,
           ]),
         ).map((element) => {
-          if (!scoreContext.value.seasonElements.includes(element)) {
+          if (!scoreContext.value.arena.seasons.includes(element)) {
             return 0
           }
 
           // @ts-expect-error ElementMythic handled here
-          return scoreContext.value.legendaryCounts[element] || 0
+          return scoreContext.value.arena.legendaryCounts[element] || 0
         }),
       ) * 4
     )
@@ -285,12 +285,12 @@ export default function useUnitScore(
     if (!unit.value.is_mythic) return 0
     if (!unit.value.element) return 0
 
-    const relevantElements = scoreContext.value.seasonElements.includes(
+    const relevantElements = scoreContext.value.arena.seasons.includes(
       unit.value.element,
     )
       ? // an in-season mythic unit receives bonuses from all in season legendaries
         intersection(
-          scoreContext.value.seasonElements,
+          scoreContext.value.arena.seasons,
           SORTED_LEGENDARY_ELEMENTS,
         )
       : chosenHero.value && chosenHeroIsInSeason.value
@@ -304,7 +304,7 @@ export default function useUnitScore(
         compact(
           relevantElements.map(
             // @ts-expect-error ElementMythic handled here
-            (element) => scoreContext.value.legendaryCounts[element],
+            (element) => scoreContext.value.arena.legendaryCounts[element],
           ),
         ),
       ) * 4
@@ -319,7 +319,7 @@ export default function useUnitScore(
   const scorePartSPs = computed(() => Math.floor(visibleSkillSPs.value / 100))
   const scorePartBST = computed(() => Math.floor(visibleBst.value / 5))
   const scorePartBlessing = computed(() =>
-    scoreContext.value.mjolnirStrike.isActive ? 0 : blessingScore.value,
+    scoreContext.value.arena.isActive ? blessingScore.value : 0,
   )
   const baseScoreBeforeBlessing = computed(() =>
     unit.value
@@ -342,9 +342,7 @@ export default function useUnitScore(
     unit.value ? baseToFinalScore(baseScore.value) : 0,
   )
 
-  const chosenHeroIsActive = computed(
-    () => !scoreContext.value.mjolnirStrike.isActive,
-  )
+  const chosenHeroIsActive = computed(() => scoreContext.value.arena.isActive)
 
   // a chosen hero attached onto a legendary only has its score used/compared
   // if it shares the same element as that legendary
@@ -382,7 +380,7 @@ export default function useUnitScore(
     let adjustedScoreContext
     if (unit.value?.is_legendary) {
       adjustedScoreContext = ref(JSON.parse(JSON.stringify(scoreContext.value)))
-      adjustedScoreContext.value.legendaryCounts[unit.value.element!] -= 1
+      adjustedScoreContext.value.arena.legendaryCounts[unit.value.element!] -= 1
     } else {
       adjustedScoreContext = scoreContext
     }

--- a/pages/score-calc.vue
+++ b/pages/score-calc.vue
@@ -70,7 +70,7 @@
 
                 <div>
                   <div>{{ t('scoreCalc.tooltips.scoreExact') }}</div>
-                  <div v-show="isMjolnirStrike">
+                  <div v-show="mjolnirStrike.isActive">
                     {{
                       t('scoreCalc.tooltips.scoreAddedByTier', {
                         score: mjolnirStrikeAddedScoreForTier,
@@ -80,12 +80,12 @@
                 </div>
               </v-tooltip>
             </div>
-            <div v-show="!isMjolnirStrike">
+            <div v-show="arena.isActive">
               <span>{{ t('scoreCalc.headers.offenseRange') }}:</span>
               {{ noUnit ? '-' : offenseScoreMin }} to
               {{ noUnit ? '-' : offenseScoreMax }}
             </div>
-            <div v-show="!isMjolnirStrike">
+            <div v-show="arena.isActive">
               <span>{{ t('scoreCalc.headers.defenseScore') }}:</span>
               {{ noUnit ? '-' : defenseScore }}
             </div>
@@ -98,18 +98,20 @@
                   md="3"
                 >
                   <v-switch
-                    v-model="isMjolnirStrike"
+                    v-model="mode"
+                    :true-value="MODE_MJOLNIR_STRIKE"
+                    :false-value="MODE_ARENA"
                     density="compact"
                     hide-details
                     :label="
-                      isMjolnirStrike
+                      mjolnirStrike.isActive
                         ? t('scoreCalc.labels.mjolnirStrike')
                         : t('scoreCalc.labels.arenaOrAA')
                     "
                   />
                 </v-col>
 
-                <template v-if="isMjolnirStrike">
+                <template v-if="mjolnirStrike.isActive">
                   <v-col
                     cols="6"
                     md="3"
@@ -150,7 +152,7 @@
                     class="d-flex align-center"
                   >
                     <div class="mr-3">{{ t('scoreCalc.labels.seasons') }}:</div>
-                    <AppSelectSeasons v-model="seasonElements" />
+                    <AppSelectSeasons v-model="arenaSeasons" />
                   </v-col>
 
                   <v-col
@@ -158,7 +160,7 @@
                     md="3"
                   >
                     <v-checkbox
-                      v-model="hasBonusUnit"
+                      v-model="arenaHasBonusUnit"
                       :label="t('scoreCalc.labels.hasBonusUnit')"
                       density="compact"
                       hide-details
@@ -249,6 +251,8 @@ import {
   encodeTeamInScoreCalc,
   getEmptyTeamInScoreCalc,
   getEmptyUnitInstanceSkillSPs,
+  MODE_ARENA,
+  MODE_MJOLNIR_STRIKE,
   OFFENSE_SCORE_DIFF_MAX,
   OFFENSE_SCORE_DIFF_MIN,
   SCT_CODE_PREFIX,
@@ -257,6 +261,8 @@ import {
   type IUnitInstanceInScoreCalc,
   type IUnitInstanceInScoreCalcV1,
   type IUnitInstanceInScoreCalcV2,
+  type Mode,
+  type ScoreContextIn,
 } from '~/utils/types/score-calc'
 import { getEmptyUnitInstanceSkillIds, type UnitId } from '~/utils/types/units'
 import {
@@ -286,15 +292,15 @@ const { isLoading: isLoadingData } = useDataStores([
 ])
 
 const DEFAULT_VALUES: {
-  isMjolnirStrike: boolean
-  hasBonusUnit: boolean
-  seasonElements: Element[]
+  mode: Mode
+  arenaHasBonusUnit: boolean
+  arenaSeasons: Element[]
   mjolnirStrikeMajor: ElementMythic
   mjolnirStrikeTier: number
 } = {
-  isMjolnirStrike: false,
-  hasBonusUnit: true,
-  seasonElements: [],
+  mode: MODE_ARENA,
+  arenaHasBonusUnit: true,
+  arenaSeasons: [],
   mjolnirStrikeMajor: ELEMENT_LIGHT,
   mjolnirStrikeTier: 21,
 }
@@ -302,9 +308,9 @@ const DEFAULT_VALUES: {
 const isLoading = computed(() => isLoadingData.value || isLoadingStorage.value)
 
 const units = ref<IUnitInstanceInScoreCalc[]>(getEmptyTeamInScoreCalc())
-const hasBonusUnit = ref(DEFAULT_VALUES.hasBonusUnit)
-const seasonElements = ref<Element[]>(DEFAULT_VALUES.seasonElements)
-const isMjolnirStrike = ref(DEFAULT_VALUES.isMjolnirStrike)
+const mode = ref<Mode>(DEFAULT_VALUES.mode)
+const arenaHasBonusUnit = ref(DEFAULT_VALUES.arenaHasBonusUnit)
+const arenaSeasons = ref<Element[]>(DEFAULT_VALUES.arenaSeasons)
 const mjolnirStrikeMajor = ref<ElementMythic>(DEFAULT_VALUES.mjolnirStrikeMajor)
 const mjolnirStrikeTier = ref<number>(DEFAULT_VALUES.mjolnirStrikeTier)
 
@@ -385,28 +391,30 @@ function confirmReset() {
   if (!confirm(t('global.confirmReset'))) return
 
   units.value = getEmptyTeamInScoreCalc()
-  hasBonusUnit.value = DEFAULT_VALUES.hasBonusUnit
-  seasonElements.value = DEFAULT_VALUES.seasonElements
-  isMjolnirStrike.value = DEFAULT_VALUES.isMjolnirStrike
+  mode.value = DEFAULT_VALUES.mode
+  arenaHasBonusUnit.value = DEFAULT_VALUES.arenaHasBonusUnit
+  arenaSeasons.value = DEFAULT_VALUES.arenaSeasons
   mjolnirStrikeMajor.value = DEFAULT_VALUES.mjolnirStrikeMajor
   mjolnirStrikeTier.value = DEFAULT_VALUES.mjolnirStrikeTier
 }
 
-const mjolnirStrike = computed(() => ({
-  isActive: isMjolnirStrike.value,
+const arena = computed<ScoreContextIn['arena']>(() => ({
+  isActive: mode.value === MODE_ARENA,
+  hasBonusUnit: arenaHasBonusUnit.value,
+  seasons: arenaSeasons.value,
+}))
+const mjolnirStrike = computed<ScoreContextIn['mjolnirStrike']>(() => ({
+  isActive: mode.value === MODE_MJOLNIR_STRIKE,
+  tier: mjolnirStrikeTier.value,
   major: mjolnirStrikeMajor.value,
   minor: mythicComplement(mjolnirStrikeMajor.value),
-  tier: mjolnirStrikeTier.value,
 }))
-const scoreContext = useScoreContext(
-  units,
-  hasBonusUnit,
-  seasonElements,
-  mjolnirStrike,
-)
+const scoreContext = useScoreContext(units, arena, mjolnirStrike)
 
 const mjolnirStrikeAddedScoreForTier = computed(() =>
-  isMjolnirStrike.value ? addedScoreForTier(mjolnirStrikeTier.value) : 0,
+  mode.value === MODE_MJOLNIR_STRIKE
+    ? addedScoreForTier(mjolnirStrikeTier.value)
+    : 0,
 )
 const averageScore = computed(() => TEAM_BASE_SCORE + mean(unitsScores.value))
 const scoreRounded = computed(
@@ -434,7 +442,7 @@ const offenseScoreMax = computed(
 // local storage
 
 const LOCAL_STORAGE_KEY = 'feh-peeler:score-calc'
-const CURRENT_PAYLOAD_VERSION = 3
+const CURRENT_PAYLOAD_VERSION = 4
 const {
   isLoading: isLoadingStorage,
   storeOnUpdate,
@@ -459,17 +467,27 @@ interface IPayloadToSaveV2 extends IPayloadToSaveCommon {
 }
 interface IPayloadToSaveV3 extends IPayloadToSaveCommon {
   version: 3
-  units: IUnitInstanceInScoreCalc[]
+  units: IUnitInstanceInScoreCalcV2[]
   mjolnirStrikeTier: number
 }
-type IPayloadToSave = IPayloadToSaveV1 | IPayloadToSaveV2 | IPayloadToSaveV3
+interface IPayloadToSaveV4 {
+  version: 4
+  units: IUnitInstanceInScoreCalcV2[]
+  mode: Mode
+  arenaHasBonusUnit: boolean
+  arenaSeasons: Element[]
+  mjolnirStrikeMajor: ElementMythic
+  mjolnirStrikeTier: number
+}
+type IPayloadToSave =
+  IPayloadToSaveV1 | IPayloadToSaveV2 | IPayloadToSaveV3 | IPayloadToSaveV4
 
-const payloadToSave = computed(() => ({
+const payloadToSave = computed<IPayloadToSaveV4>(() => ({
   version: CURRENT_PAYLOAD_VERSION,
   units: units.value,
-  hasBonusUnit: hasBonusUnit.value,
-  seasonElements: seasonElements.value,
-  isMjolnirStrike: isMjolnirStrike.value,
+  mode: mode.value,
+  arenaHasBonusUnit: arenaHasBonusUnit.value,
+  arenaSeasons: arenaSeasons.value,
   mjolnirStrikeMajor: mjolnirStrikeMajor.value,
   mjolnirStrikeTier: mjolnirStrikeTier.value,
 }))
@@ -477,9 +495,21 @@ storeOnUpdate(payloadToSave)
 updateOnMounted(updateData)
 
 function updateData(data: IPayloadToSave) {
-  hasBonusUnit.value = data.hasBonusUnit
-  seasonElements.value = data.seasonElements || []
-  isMjolnirStrike.value = data.isMjolnirStrike
+  if (data.version === 4) {
+    mode.value = data.mode || DEFAULT_VALUES.mode
+    arenaHasBonusUnit.value = data.arenaHasBonusUnit
+    arenaSeasons.value = data.arenaSeasons || []
+    mjolnirStrikeMajor.value =
+      data.mjolnirStrikeMajor || DEFAULT_VALUES.mjolnirStrikeMajor
+    units.value = data.units || []
+    mjolnirStrikeTier.value =
+      data.mjolnirStrikeTier || DEFAULT_VALUES.mjolnirStrikeTier
+    return
+  }
+
+  arenaHasBonusUnit.value = data.hasBonusUnit
+  arenaSeasons.value = data.seasonElements || []
+  mode.value = data.isMjolnirStrike ? MODE_MJOLNIR_STRIKE : MODE_ARENA
   mjolnirStrikeMajor.value =
     data.mjolnirStrikeMajor || DEFAULT_VALUES.mjolnirStrikeMajor
 

--- a/test/composables/useUnitScore.test.ts
+++ b/test/composables/useUnitScore.test.ts
@@ -16,7 +16,10 @@ import useUnitScore from '~/composables/useUnitScore'
 import useScoreContext from '~/composables/useScoreContext'
 import {
   decodeTeamInScoreCalc,
+  MODE_ARENA,
+  MODE_MJOLNIR_STRIKE,
   TEAM_BASE_SCORE,
+  type Mode,
 } from '~/utils/types/score-calc'
 import {
   ELEMENT_FIRE,
@@ -50,8 +53,13 @@ interface TeamCase {
   name: string
   code: string
   context: {
-    hasBonusUnit: boolean
-    seasonElements: Element[]
+    // mirrors pages/score-calc.vue's own mode ref: MODE_ARENA unless
+    // mjolnirStrike below is set, in which case MODE_MJOLNIR_STRIKE
+    mode: Mode
+    arena?: {
+      hasBonusUnit: boolean
+      seasons: Element[]
+    }
     // when set, mirrors pages/score-calc.vue's Mjölnir's Strike mode: the
     // team-score computation switches to the tier-adjusted formula below,
     // and useScoreContext() forces bonusFactor to 2 and disables blessings
@@ -76,8 +84,11 @@ const TEAM_STANDARD: TeamCase = {
   name: 'standard team (boons/banes, chosen hero, duel skills)',
   code: 'SCTv1:W3siaWQiOiJQSURf44Ki44Or44OV44Kp44Oz44K5Iiwic2tpbGxJZHMiOnsicGFzc2l2ZWEiOiJTSURf6LWk44Gu5q276ZeY44O75q2p6KGMMSJ9LCJyYXJpdHkiOjUsImxldmVsIjo0MCwibWVyZ2VzIjoyLCJib29uIjoiYXRrIiwiYmFuZSI6ImRlZiIsImJsZXNzaW5nIjoiRmlyZSIsInNraWxsU1BzIjp7InBhc3NpdmVhIjo3MCwicGFzc2l2ZWIiOjEyMCwicGFzc2l2ZWMiOjgwLCJzYWNyZWRzZWFsIjo1MH0sImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH0seyJpZCI6IlBJRF/kvJ3mib/mvIbpu5Ljga7pqI7lo6siLCJza2lsbElkcyI6e30sInJhcml0eSI6NSwibGV2ZWwiOjQwLCJtZXJnZXMiOjQsImJvb24iOm51bGwsImJhbmUiOm51bGwsImJsZXNzaW5nIjpudWxsLCJza2lsbFNQcyI6eyJ3ZWFwb24iOjEwMCwic3BlY2lhbCI6MTAwLCJzYWNyZWRzZWFsIjo1MH0sImNob3Nlbkhlcm9JZCI6IlBJRF/mlZHkuJbjg5XjgqPjg6jjg6vjg6AiLCJjaG9zZW5IZXJvTWVyZ2VzIjozfSx7ImlkIjoiUElEX+aVkeS4luODleOCo+ODqOODq+ODoCIsInNraWxsSWRzIjp7fSwicmFyaXR5Ijo1LCJsZXZlbCI6NDAsIm1lcmdlcyI6MSwiYm9vbiI6bnVsbCwiYmFuZSI6bnVsbCwiYmxlc3NpbmciOm51bGwsInNraWxsU1BzIjp7fSwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfSx7ImlkIjoiUElEX+ODq+ODvOODsyIsInNraWxsSWRzIjp7InBhc3NpdmVhIjoiU0lEX+eEoeOBruatu+mXmOODu+atqeihjDQifSwicmFyaXR5Ijo1LCJsZXZlbCI6NDAsIm1lcmdlcyI6MCwiYm9vbiI6bnVsbCwiYmFuZSI6bnVsbCwiYmxlc3NpbmciOm51bGwsInNraWxsU1BzIjp7InBhc3NpdmVhIjozMDB9LCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9XQ==',
   context: {
-    hasBonusUnit: false,
-    seasonElements: [ELEMENT_FIRE, ELEMENT_WATER],
+    mode: MODE_ARENA,
+    arena: {
+      hasBonusUnit: false,
+      seasons: [ELEMENT_FIRE, ELEMENT_WATER],
+    },
   },
   expectedVisibleFinalScores: [341, 351, 370, 338],
   expectedTeamFinalScore: 350,
@@ -89,8 +100,11 @@ const TEAM_BONUS_FACTOR: TeamCase = {
   name: 'team with the bonus-unit x2 factor',
   code: 'SCTv1:W3siaWQiOiJQSURf5q+U57+844Or44Kt44OKIiwic2tpbGxJZHMiOnsid2VhcG9uIjoiU0lEX+iBlueOi+WbveOBrueItuWomOOBruelnuW8kyIsImFzc2lzdCI6IlNJRF/mnKrmnaXjgpLlj7bjgYjjgovnnrMiLCJzcGVjaWFsIjoiU0lEX+absuWwhCIsInBhc3NpdmVhIjoiU0lEX+msvOelnumjm+eHleOBruaOqeaSgyIsInBhc3NpdmViIjoiU0lEX+mAn+OBleWuiOWCmeOBrueci+egtCIsInBhc3NpdmVjIjoiU0lEX+S4jeayu+OBruW5u+eFmTQiLCJzYWNyZWRzZWFsIjoiU1NJRF/ov5Hlj43jg7vlvJPmmpflsILnlKgifSwic2tpbGxTUHMiOnsid2VhcG9uIjo0MDAsImFzc2lzdCI6NDAwLCJzcGVjaWFsIjo1MDAsInBhc3NpdmVhIjozMDAsInBhc3NpdmViIjozMDAsInBhc3NpdmVjIjozMDAsInNhY3JlZHNlYWwiOjMwMCwicGFzc2l2ZXgiOjB9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjoxMCwiYm9vbiI6InNwZCIsImJhbmUiOm51bGwsImJsZXNzaW5nIjoiV2F0ZXIiLCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9LHsiaWQiOiJQSURf44Op44OV44Kh44Ko44OrIiwic2tpbGxJZHMiOnsid2VhcG9uIjoiU0lEX+mtlOWZqOODu+ODqOODiOOCpeODs+OBruaWpyIsImFzc2lzdCI6IlNJRF/lhaXjgozmm7/jgYjjg7vmranms5UiLCJzcGVjaWFsIjoiU0lEX+mHjeijheOBruWPjOeCjiIsInBhc3NpdmVhIjoiU0lEX+eBq+WcsOawtOOBruWRveiEiCIsInBhc3NpdmViIjoiU0lEX+W+jOOBruWFiCIsInBhc3NpdmVjIjoiU0lEX+mOp+OBruitt+OCiuaJi+ODu+eQhuODu+iMqCIsInNhY3JlZHNlYWwiOiJTU0lEX+mBoOWPjeODu+WJo+anjeaWp+WwgueUqCJ9LCJza2lsbFNQcyI6eyJ3ZWFwb24iOjM1MCwiYXNzaXN0Ijo0MDAsInNwZWNpYWwiOjUwMCwicGFzc2l2ZWEiOjMwMCwicGFzc2l2ZWIiOjQwMCwicGFzc2l2ZWMiOjMwMCwic2FjcmVkc2VhbCI6MzAwLCJwYXNzaXZleCI6MH0sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjEwLCJib29uIjoiYXRrIiwiYmFuZSI6bnVsbCwiYmxlc3NpbmciOiJXYXRlciIsImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH0seyJpZCI6IlBJRF/jgq7jg6Djg6zjg7znlLciLCJza2lsbElkcyI6eyJ3ZWFwb24iOiJTSURf6a2U5Zmo44O75bm856We44Gu44OW44Os44K5IiwiYXNzaXN0IjoiU0lEX+WFpeOCjOabv+OBiOODu+atqeazlSIsInNwZWNpYWwiOiJTSURf6YeN6KOF44Gu5Y+M5rC3IiwicGFzc2l2ZWEiOiJTSURf54Gr5Zyw5rC044Gu5ZG96ISIIiwicGFzc2l2ZWIiOiJTSURf5b6M44Gu5YWIIiwicGFzc2l2ZWMiOiJTSURf6KGj44Gu6K2344KK5omL44O76a2U44O76IyoIiwic2FjcmVkc2VhbCI6IlNTSURf6YGg5Y+N44O756uc5bCC55SoIn0sInNraWxsU1BzIjp7IndlYXBvbiI6MzUwLCJhc3Npc3QiOjQwMCwic3BlY2lhbCI6NTAwLCJwYXNzaXZlYSI6MzAwLCJwYXNzaXZlYiI6NDAwLCJwYXNzaXZlYyI6MzAwLCJzYWNyZWRzZWFsIjozMDAsInBhc3NpdmV4IjowfSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6MTAsImJvb24iOiJhdGsiLCJiYW5lIjpudWxsLCJibGVzc2luZyI6IldhdGVyIiwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfSx7ImlkIjoiUElEX+S8neaJv+ODi+ODi+OCouODsyIsInNraWxsSWRzIjp7IndlYXBvbiI6IlNJRF/npZ7oiJ7jga7jg5bjg6zjgrlf5LiAIiwiYXNzaXN0IjoiU0lEX+WwiuOBjeernOOBruihgOOCkuKApuODu+aJvyIsInNwZWNpYWwiOiJTSURf56uc44Gu5ZKG5ZOuIiwicGFzc2l2ZWEiOiJTSURf5pS75pKD6YCf44GV44Gu56qB56C0IiwicGFzc2l2ZWIiOiJTSURf56uc6bGX6Zqc5aOB44O75a++6Lui56e7IiwicGFzc2l2ZWMiOiJTSURf5b2x5Yqp44O75byV44GN5oi744GXNCIsInNhY3JlZHNlYWwiOiJTU0lEX+aUu+aSg+mAn+OBleOBrua/gOeqgTMifSwic2tpbGxTUHMiOnsid2VhcG9uIjo0MDAsImFzc2lzdCI6NDAwLCJzcGVjaWFsIjo1MDAsInBhc3NpdmVhIjozMDAsInBhc3NpdmViIjo0MDAsInBhc3NpdmVjIjozMDAsInNhY3JlZHNlYWwiOjI0MCwicGFzc2l2ZXgiOjB9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjoxLCJib29uIjoic3BkIiwiYmFuZSI6bnVsbCwiYmxlc3NpbmciOiJXYXRlciIsImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH1d',
   context: {
-    hasBonusUnit: true,
-    seasonElements: [ELEMENT_FIRE, ELEMENT_WATER],
+    mode: MODE_ARENA,
+    arena: {
+      hasBonusUnit: true,
+      seasons: [ELEMENT_FIRE, ELEMENT_WATER],
+    },
   },
   expectedVisibleFinalScores: [780, 780, 778, 726],
   expectedTeamFinalScore: 766,
@@ -103,8 +117,11 @@ const TEAM_BONUS_FACTOR_CHOSEN_HERO_DIFFERENT_ELEMENT: TeamCase = {
   name: 'team with the bonus-unit x2 factor, chosen hero of a different element attached to the legendary',
   code: 'SCTv1:W3siaWQiOiJQSURf5q+U57+844Or44Kt44OKIiwic2tpbGxJZHMiOnsid2VhcG9uIjoiU0lEX+iBlueOi+WbveOBrueItuWomOOBruelnuW8kyIsImFzc2lzdCI6IlNJRF/mnKrmnaXjgpLlj7bjgYjjgovnnrMiLCJzcGVjaWFsIjoiU0lEX+absuWwhCIsInBhc3NpdmVhIjoiU0lEX+msvOelnumjm+eHleOBruaOqeaSgyIsInBhc3NpdmViIjoiU0lEX+mAn+OBleWuiOWCmeOBrueci+egtCIsInBhc3NpdmVjIjoiU0lEX+S4jeayu+OBruW5u+eFmTQiLCJzYWNyZWRzZWFsIjoiU1NJRF/ov5Hlj43jg7vlvJPmmpflsILnlKgifSwic2tpbGxTUHMiOnsid2VhcG9uIjo0MDAsImFzc2lzdCI6NDAwLCJzcGVjaWFsIjo1MDAsInBhc3NpdmVhIjozMDAsInBhc3NpdmViIjozMDAsInBhc3NpdmVjIjozMDAsInNhY3JlZHNlYWwiOjMwMCwicGFzc2l2ZXgiOjB9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjoxMCwiYm9vbiI6InNwZCIsImJhbmUiOm51bGwsImJsZXNzaW5nIjoiV2F0ZXIiLCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9LHsiaWQiOiJQSURf44Op44OV44Kh44Ko44OrIiwic2tpbGxJZHMiOnsid2VhcG9uIjoiU0lEX+mtlOWZqOODu+ODqOODiOOCpeODs+OBruaWpyIsImFzc2lzdCI6IlNJRF/lhaXjgozmm7/jgYjjg7vmranms5UiLCJzcGVjaWFsIjoiU0lEX+mHjeijheOBruWPjOeCjiIsInBhc3NpdmVhIjoiU0lEX+eBq+WcsOawtOOBruWRveiEiCIsInBhc3NpdmViIjoiU0lEX+W+jOOBruWFiCIsInBhc3NpdmVjIjoiU0lEX+mOp+OBruitt+OCiuaJi+ODu+eQhuODu+iMqCIsInNhY3JlZHNlYWwiOiJTU0lEX+mBoOWPjeODu+WJo+anjeaWp+WwgueUqCJ9LCJza2lsbFNQcyI6eyJ3ZWFwb24iOjM1MCwiYXNzaXN0Ijo0MDAsInNwZWNpYWwiOjUwMCwicGFzc2l2ZWEiOjMwMCwicGFzc2l2ZWIiOjQwMCwicGFzc2l2ZWMiOjMwMCwic2FjcmVkc2VhbCI6MzAwLCJwYXNzaXZleCI6MH0sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjEwLCJib29uIjoiYXRrIiwiYmFuZSI6bnVsbCwiYmxlc3NpbmciOiJXYXRlciIsImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH0seyJpZCI6IlBJRF/jgq7jg6Djg6zjg7znlLciLCJza2lsbElkcyI6eyJ3ZWFwb24iOiJTSURf6a2U5Zmo44O75bm856We44Gu44OW44Os44K5IiwiYXNzaXN0IjoiU0lEX+WFpeOCjOabv+OBiOODu+atqeazlSIsInNwZWNpYWwiOiJTSURf6YeN6KOF44Gu5Y+M5rC3IiwicGFzc2l2ZWEiOiJTSURf54Gr5Zyw5rC044Gu5ZG96ISIIiwicGFzc2l2ZWIiOiJTSURf5b6M44Gu5YWIIiwicGFzc2l2ZWMiOiJTSURf6KGj44Gu6K2344KK5omL44O76a2U44O76IyoIiwic2FjcmVkc2VhbCI6IlNTSURf6YGg5Y+N44O756uc5bCC55SoIn0sInNraWxsU1BzIjp7IndlYXBvbiI6MzUwLCJhc3Npc3QiOjQwMCwic3BlY2lhbCI6NTAwLCJwYXNzaXZlYSI6MzAwLCJwYXNzaXZlYiI6NDAwLCJwYXNzaXZlYyI6MzAwLCJzYWNyZWRzZWFsIjozMDAsInBhc3NpdmV4IjowfSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6MTAsImJvb24iOiJhdGsiLCJiYW5lIjpudWxsLCJibGVzc2luZyI6IldhdGVyIiwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfSx7ImlkIjoiUElEX+S8neaJv+ODi+ODi+OCouODsyIsInNraWxsSWRzIjp7IndlYXBvbiI6IlNJRF/npZ7oiJ7jga7jg5bjg6zjgrlf5LiAIiwiYXNzaXN0IjoiU0lEX+WwiuOBjeernOOBruihgOOCkuKApuODu+aJvyIsInNwZWNpYWwiOiJTSURf56uc44Gu5ZKG5ZOuIiwicGFzc2l2ZWEiOiJTSURf5pS75pKD6YCf44GV44Gu56qB56C0IiwicGFzc2l2ZWIiOiJTSURf56uc6bGX6Zqc5aOB44O75a++6Lui56e7IiwicGFzc2l2ZWMiOiJTSURf5b2x5Yqp44O75byV44GN5oi744GXNCIsInNhY3JlZHNlYWwiOiJTU0lEX+aUu+aSg+mAn+OBleOBrua/gOeqgTMifSwic2tpbGxTUHMiOnsid2VhcG9uIjo0MDAsImFzc2lzdCI6NDAwLCJzcGVjaWFsIjo1MDAsInBhc3NpdmVhIjozMDAsInBhc3NpdmViIjo0MDAsInBhc3NpdmVjIjozMDAsInNhY3JlZHNlYWwiOjI0MCwicGFzc2l2ZXgiOjB9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjoxLCJib29uIjoic3BkIiwiYmFuZSI6bnVsbCwiYmxlc3NpbmciOiJXYXRlciIsImNob3Nlbkhlcm9JZCI6IlBJRF/mlZHkuJbjgqLjg6vjg5Xjgqnjg7PjgrkiLCJjaG9zZW5IZXJvTWVyZ2VzIjo1fV0=',
   context: {
-    hasBonusUnit: true,
-    seasonElements: [ELEMENT_FIRE, ELEMENT_WATER],
+    mode: MODE_ARENA,
+    arena: {
+      hasBonusUnit: true,
+      seasons: [ELEMENT_FIRE, ELEMENT_WATER],
+    },
   },
   expectedVisibleFinalScores: [780, 780, 778, 726],
   expectedTeamFinalScore: 766,
@@ -121,8 +138,11 @@ const TEAM_BONUS_LEGENDARY_NO_OTHER_LEGENDARY: TeamCase = {
   name: 'L!Camilla as bonus unit w/o other legendaries',
   code: 'SCTv1:W3siaWQiOiJQSURf5Lyd5om/44Kr44Of44OpIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjpudWxsLCJiYW5lIjpudWxsLCJibGVzc2luZyI6IldhdGVyIiwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOiJQSURf5pWR5LiW44OV44Kj44Oo44Or44OgIiwiY2hvc2VuSGVyb01lcmdlcyI6Mn0seyJpZCI6IlBJRF/mr5Tnv7zjg5jjgq/jg4jjg6siLCJza2lsbElkcyI6e30sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjAsImJvb24iOm51bGwsImJhbmUiOm51bGwsImJsZXNzaW5nIjpudWxsLCJza2lsbFNQcyI6e30sImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH0seyJpZCI6IlBJRF/mr5Tnv7zjg6zjg7zjgq7jg6Pjg6vjg7MiLCJza2lsbElkcyI6e30sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjAsImJvb24iOm51bGwsImJhbmUiOm51bGwsImJsZXNzaW5nIjpudWxsLCJza2lsbFNQcyI6e30sImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH0seyJpZCI6IlBJRF/jgq/jg6rjgrnlpbMiLCJza2lsbElkcyI6e30sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjAsImJvb24iOm51bGwsImJhbmUiOm51bGwsImJsZXNzaW5nIjpudWxsLCJza2lsbFNQcyI6e30sImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH1d',
   context: {
-    hasBonusUnit: true,
-    seasonElements: [ELEMENT_WATER],
+    mode: MODE_ARENA,
+    arena: {
+      hasBonusUnit: true,
+      seasons: [ELEMENT_WATER],
+    },
   },
   expectedVisibleFinalScores: [744, 670, 676, 664],
   expectedTeamFinalScore: 688,
@@ -132,8 +152,11 @@ const TEAM_BONUS_LEGENDARY_1_OTHER_LEGENDARY: TeamCase = {
   name: 'L!Camilla as bonus unit w/ 1 other legendary',
   code: 'SCTv1:W3siaWQiOiJQSURf5Lyd5om/44Kr44Of44OpIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjpudWxsLCJiYW5lIjpudWxsLCJibGVzc2luZyI6IldhdGVyIiwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOiJQSURf5pWR5LiW44OV44Kj44Oo44Or44OgIiwiY2hvc2VuSGVyb01lcmdlcyI6Mn0seyJpZCI6IlBJRF/kvJ3mib/jg5njg6zjg4giLCJza2lsbElkcyI6e30sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjAsImJvb24iOm51bGwsImJhbmUiOm51bGwsImJsZXNzaW5nIjoiV2F0ZXIiLCJza2lsbFNQcyI6e30sImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH0seyJpZCI6IlBJRF/mr5Tnv7zjg6zjg7zjgq7jg6Pjg6vjg7MiLCJza2lsbElkcyI6e30sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjAsImJvb24iOm51bGwsImJhbmUiOm51bGwsImJsZXNzaW5nIjpudWxsLCJza2lsbFNQcyI6e30sImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH0seyJpZCI6IlBJRF/jgq/jg6rjgrnlpbMiLCJza2lsbElkcyI6e30sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjAsImJvb24iOm51bGwsImJhbmUiOm51bGwsImJsZXNzaW5nIjpudWxsLCJza2lsbFNQcyI6e30sImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH1d',
   context: {
-    hasBonusUnit: true,
-    seasonElements: [ELEMENT_WATER],
+    mode: MODE_ARENA,
+    arena: {
+      hasBonusUnit: true,
+      seasons: [ELEMENT_WATER],
+    },
   },
   expectedVisibleFinalScores: [744, 670, 676, 664],
   expectedTeamFinalScore: 688,
@@ -143,8 +166,11 @@ const TEAM_BONUS_LEGENDARY_2_OTHER_LEGENDARIES: TeamCase = {
   name: 'L!Camilla as bonus unit w/ 2 other legendaries',
   code: 'SCTv1:W3siaWQiOiJQSURf5Lyd5om/44Kr44Of44OpIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjpudWxsLCJiYW5lIjpudWxsLCJibGVzc2luZyI6IldhdGVyIiwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOiJQSURf5pWR5LiW44OV44Kj44Oo44Or44OgIiwiY2hvc2VuSGVyb01lcmdlcyI6Mn0seyJpZCI6IlBJRF/kvJ3mib/jg5njg6zjg4giLCJza2lsbElkcyI6e30sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjAsImJvb24iOm51bGwsImJhbmUiOm51bGwsImJsZXNzaW5nIjoiV2F0ZXIiLCJza2lsbFNQcyI6e30sImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH0seyJpZCI6IlBJRF/kvJ3mib/jgq7jg43jg7TjgqPjgqIiLCJza2lsbElkcyI6e30sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjAsImJvb24iOm51bGwsImJhbmUiOm51bGwsImJsZXNzaW5nIjoiV2F0ZXIiLCJza2lsbFNQcyI6e30sImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH0seyJpZCI6IlBJRF/jgq/jg6rjgrnlpbMiLCJza2lsbElkcyI6e30sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjAsImJvb24iOm51bGwsImJhbmUiOm51bGwsImJsZXNzaW5nIjpudWxsLCJza2lsbFNQcyI6e30sImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH1d',
   context: {
-    hasBonusUnit: true,
-    seasonElements: [ELEMENT_WATER],
+    mode: MODE_ARENA,
+    arena: {
+      hasBonusUnit: true,
+      seasons: [ELEMENT_WATER],
+    },
   },
   expectedVisibleFinalScores: [744, 670, 676, 664],
   expectedTeamFinalScore: 688,
@@ -159,8 +185,11 @@ const TEAM_ANNA_BASE: TeamCase = {
   name: 'chosen hero blessing bonus: base team, no chosen hero attached',
   code: 'SCTv1:W3siaWQiOiJQSURf44Ki44Oz44OKIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoic3BkIiwiYmFuZSI6InJlcyIsImJsZXNzaW5nIjoiTGlnaHQiLCJza2lsbFNQcyI6e30sImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH0seyJpZCI6IlBJRF/jgqzjg6vjgrfjgqIiLCJza2lsbElkcyI6eyJ3ZWFwb24iOiJTSURf5oSb44Gu56Wt44Gu5pan77yLIiwiYXNzaXN0IjoiU0lEX+W8leOBjeaIu+OBl+ODu+atqeazlSIsInNwZWNpYWwiOiJTSURf6KeS6YCQIiwicGFzc2l2ZWEiOiJTSURf5r+B5rWB44Gu5LiA5pKDIiwicGFzc2l2ZWIiOiJTSURf5b6M44Gu5YWIIiwicGFzc2l2ZWMiOiJTSURf5pS75pKD6YCf44GV44Gu5L+h5b+1Iiwic2FjcmVkc2VhbCI6IlNTSURf5LiN5YuV44Gu5ae/5YuiMyJ9LCJza2lsbFNQcyI6eyJ3ZWFwb24iOjM1MCwiYXNzaXN0Ijo0MDAsInNwZWNpYWwiOjUwMCwicGFzc2l2ZWEiOjMwMCwicGFzc2l2ZWIiOjQwMCwicGFzc2l2ZWMiOjMwMCwic2FjcmVkc2VhbCI6MjAwLCJwYXNzaXZleCI6MH0sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjEwLCJib29uIjpudWxsLCJiYW5lIjpudWxsLCJibGVzc2luZyI6IkVhcnRoIiwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfSx7ImlkIjoiUElEX+S8neaJv+OCr+ODreODvOODiSIsInNraWxsSWRzIjp7IndlYXBvbiI6IlNJRF/jg5XjgqfjgqTjg6vjg47jg7zjg4hf5LiAIiwiYXNzaXN0IjoiU0lEX+mAn+OBleWuiOWCmeOBruW/nOaPtO+8iyIsInNwZWNpYWwiOiJTSURf5puy5bCEIiwicGFzc2l2ZWEiOiJTSURf6ay856We6aOb54eV44Gu54KO5pKDMyIsInBhc3NpdmViIjoiU0lEX+iQveaYn+ODu+aJvyIsInBhc3NpdmVjIjoiU0lEX+S4jeayu+OBruW5u+eFmTQiLCJzYWNyZWRzZWFsIjoiU1NJRF/ov5Hlj43jg7vlvJPmmpflsILnlKgifSwic2tpbGxTUHMiOnsid2VhcG9uIjo0MDAsImFzc2lzdCI6NDAwLCJzcGVjaWFsIjo1MDAsInBhc3NpdmVhIjozMDAsInBhc3NpdmViIjozMDAsInBhc3NpdmVjIjozMDAsInNhY3JlZHNlYWwiOjMwMCwicGFzc2l2ZXgiOjB9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjoxMCwiYm9vbiI6InNwZCIsImJhbmUiOm51bGwsImJsZXNzaW5nIjoiRWFydGgiLCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9LHsiaWQiOiJQSURf44Kw44Ot44O844Oh44OrIiwic2tpbGxJZHMiOnsid2VhcG9uIjoiU0lEX+ODnOODq+ODiOOCouOCr+OCuSIsImFzc2lzdCI6IlNJRF/mlLvmkoPlrojlgpnjga7lv5zmj7TvvIsiLCJzcGVjaWFsIjoiU0lEX+inkumAkCIsInBhc3NpdmVhIjoiU0lEX+msvOelnumjm+eHleOBrueCjuaSgzMiLCJwYXNzaXZlYiI6IlNJRF/lpKnoiJ7jgYTnq4vjgaQiLCJwYXNzaXZlYyI6IlNJRF/mlLvmkoPpgJ/jgZXjga7kv6Hnvqk0Iiwic2FjcmVkc2VhbCI6IlNTSURf6YGg5Y+N44O75Ymj5qeN5pan5bCC55SoIn0sInNraWxsU1BzIjp7IndlYXBvbiI6NDAwLCJhc3Npc3QiOjQwMCwic3BlY2lhbCI6NTAwLCJwYXNzaXZlYSI6MzAwLCJwYXNzaXZlYiI6NDAwLCJwYXNzaXZlYyI6MzAwLCJzYWNyZWRzZWFsIjozMDAsInBhc3NpdmV4IjowfSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6MTAsImJvb24iOm51bGwsImJhbmUiOm51bGwsImJsZXNzaW5nIjoiRWFydGgiLCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9XQ==',
   context: {
-    hasBonusUnit: true,
-    seasonElements: [ELEMENT_WATER, ELEMENT_EARTH],
+    mode: MODE_ARENA,
+    arena: {
+      hasBonusUnit: true,
+      seasons: [ELEMENT_WATER, ELEMENT_EARTH],
+    },
   },
   expectedVisibleFinalScores: [658, 774, 760, 776],
   expectedTeamFinalScore: 742,
@@ -170,8 +199,11 @@ const TEAM_ANNA_WITH_CHOSEN_HERO: TeamCase = {
   name: 'chosen hero blessing bonus: C!Fjorm attached to Anna',
   code: 'SCTv1:W3siaWQiOiJQSURf44Ki44Oz44OKIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoic3BkIiwiYmFuZSI6InJlcyIsImJsZXNzaW5nIjoiTGlnaHQiLCJza2lsbFNQcyI6e30sImNob3Nlbkhlcm9JZCI6IlBJRF/mlZHkuJbjg5XjgqPjg6jjg6vjg6AiLCJjaG9zZW5IZXJvTWVyZ2VzIjowfSx7ImlkIjoiUElEX+OCrOODq+OCt+OCoiIsInNraWxsSWRzIjp7IndlYXBvbiI6IlNJRF/mhJvjga7npa3jga7mlqfvvIsiLCJhc3Npc3QiOiJTSURf5byV44GN5oi744GX44O75q2p5rOVIiwic3BlY2lhbCI6IlNJRF/op5LpgJAiLCJwYXNzaXZlYSI6IlNJRF/mv4HmtYHjga7kuIDmkoMiLCJwYXNzaXZlYiI6IlNJRF/lvozjga7lhYgiLCJwYXNzaXZlYyI6IlNJRF/mlLvmkoPpgJ/jgZXjga7kv6Hlv7UiLCJzYWNyZWRzZWFsIjoiU1NJRF/kuI3li5Xjga7lp7/li6IzIn0sInNraWxsU1BzIjp7IndlYXBvbiI6MzUwLCJhc3Npc3QiOjQwMCwic3BlY2lhbCI6NTAwLCJwYXNzaXZlYSI6MzAwLCJwYXNzaXZlYiI6NDAwLCJwYXNzaXZlYyI6MzAwLCJzYWNyZWRzZWFsIjoyMDAsInBhc3NpdmV4IjowfSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6MTAsImJvb24iOm51bGwsImJhbmUiOm51bGwsImJsZXNzaW5nIjoiRWFydGgiLCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9LHsiaWQiOiJQSURf5Lyd5om/44Kv44Ot44O844OJIiwic2tpbGxJZHMiOnsid2VhcG9uIjoiU0lEX+ODleOCp+OCpOODq+ODjuODvOODiF/kuIAiLCJhc3Npc3QiOiJTSURf6YCf44GV5a6I5YKZ44Gu5b+c5o+077yLIiwic3BlY2lhbCI6IlNJRF/mm7LlsIQiLCJwYXNzaXZlYSI6IlNJRF/prLznpZ7po5vnh5Xjga7ngo7mkoMzIiwicGFzc2l2ZWIiOiJTSURf6JC95pif44O75om/IiwicGFzc2l2ZWMiOiJTSURf5LiN5rK744Gu5bm754WZNCIsInNhY3JlZHNlYWwiOiJTU0lEX+i/keWPjeODu+W8k+aal+WwgueUqCJ9LCJza2lsbFNQcyI6eyJ3ZWFwb24iOjQwMCwiYXNzaXN0Ijo0MDAsInNwZWNpYWwiOjUwMCwicGFzc2l2ZWEiOjMwMCwicGFzc2l2ZWIiOjMwMCwicGFzc2l2ZWMiOjMwMCwic2FjcmVkc2VhbCI6MzAwLCJwYXNzaXZleCI6MH0sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjEwLCJib29uIjoic3BkIiwiYmFuZSI6bnVsbCwiYmxlc3NpbmciOiJFYXJ0aCIsImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH0seyJpZCI6IlBJRF/jgrDjg63jg7zjg6Hjg6siLCJza2lsbElkcyI6eyJ3ZWFwb24iOiJTSURf44Oc44Or44OI44Ki44Kv44K5IiwiYXNzaXN0IjoiU0lEX+aUu+aSg+WuiOWCmeOBruW/nOaPtO+8iyIsInNwZWNpYWwiOiJTSURf6KeS6YCQIiwicGFzc2l2ZWEiOiJTSURf6ay856We6aOb54eV44Gu54KO5pKDMyIsInBhc3NpdmViIjoiU0lEX+WkqeiInuOBhOeri+OBpCIsInBhc3NpdmVjIjoiU0lEX+aUu+aSg+mAn+OBleOBruS/oee+qTQiLCJzYWNyZWRzZWFsIjoiU1NJRF/pgaDlj43jg7vliaPmp43mlqflsILnlKgifSwic2tpbGxTUHMiOnsid2VhcG9uIjo0MDAsImFzc2lzdCI6NDAwLCJzcGVjaWFsIjo1MDAsInBhc3NpdmVhIjozMDAsInBhc3NpdmViIjo0MDAsInBhc3NpdmVjIjozMDAsInNhY3JlZHNlYWwiOjMwMCwicGFzc2l2ZXgiOjB9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjoxMCwiYm9vbiI6bnVsbCwiYmFuZSI6bnVsbCwiYmxlc3NpbmciOiJFYXJ0aCIsImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH1d',
   context: {
-    hasBonusUnit: true,
-    seasonElements: [ELEMENT_WATER, ELEMENT_EARTH],
+    mode: MODE_ARENA,
+    arena: {
+      hasBonusUnit: true,
+      seasons: [ELEMENT_WATER, ELEMENT_EARTH],
+    },
   },
   expectedVisibleFinalScores: [736, 774, 760, 776],
   expectedTeamFinalScore: 760,
@@ -182,8 +214,11 @@ const TEAM_ANNA_WITH_CHOSEN_HERO_AND_BLESSING: TeamCase = {
   name: 'chosen hero blessing bonus: C!Fjorm attached to Anna, Anna blessed Earth',
   code: 'SCTv1:W3siaWQiOiJQSURf44Ki44Oz44OKIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoic3BkIiwiYmFuZSI6InJlcyIsImJsZXNzaW5nIjoiRWFydGgiLCJza2lsbFNQcyI6e30sImNob3Nlbkhlcm9JZCI6IlBJRF/mlZHkuJbjg5XjgqPjg6jjg6vjg6AiLCJjaG9zZW5IZXJvTWVyZ2VzIjowfSx7ImlkIjoiUElEX+OCrOODq+OCt+OCoiIsInNraWxsSWRzIjp7IndlYXBvbiI6IlNJRF/mhJvjga7npa3jga7mlqfvvIsiLCJhc3Npc3QiOiJTSURf5byV44GN5oi744GX44O75q2p5rOVIiwic3BlY2lhbCI6IlNJRF/op5LpgJAiLCJwYXNzaXZlYSI6IlNJRF/mv4HmtYHjga7kuIDmkoMiLCJwYXNzaXZlYiI6IlNJRF/lvozjga7lhYgiLCJwYXNzaXZlYyI6IlNJRF/mlLvmkoPpgJ/jgZXjga7kv6Hlv7UiLCJzYWNyZWRzZWFsIjoiU1NJRF/kuI3li5Xjga7lp7/li6IzIn0sInNraWxsU1BzIjp7IndlYXBvbiI6MzUwLCJhc3Npc3QiOjQwMCwic3BlY2lhbCI6NTAwLCJwYXNzaXZlYSI6MzAwLCJwYXNzaXZlYiI6NDAwLCJwYXNzaXZlYyI6MzAwLCJzYWNyZWRzZWFsIjoyMDAsInBhc3NpdmV4IjowfSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6MTAsImJvb24iOm51bGwsImJhbmUiOm51bGwsImJsZXNzaW5nIjoiRWFydGgiLCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9LHsiaWQiOiJQSURf5Lyd5om/44Kv44Ot44O844OJIiwic2tpbGxJZHMiOnsid2VhcG9uIjoiU0lEX+ODleOCp+OCpOODq+ODjuODvOODiF/kuIAiLCJhc3Npc3QiOiJTSURf6YCf44GV5a6I5YKZ44Gu5b+c5o+077yLIiwic3BlY2lhbCI6IlNJRF/mm7LlsIQiLCJwYXNzaXZlYSI6IlNJRF/prLznpZ7po5vnh5Xjga7ngo7mkoMzIiwicGFzc2l2ZWIiOiJTSURf6JC95pif44O75om/IiwicGFzc2l2ZWMiOiJTSURf5LiN5rK744Gu5bm754WZNCIsInNhY3JlZHNlYWwiOiJTU0lEX+i/keWPjeODu+W8k+aal+WwgueUqCJ9LCJza2lsbFNQcyI6eyJ3ZWFwb24iOjQwMCwiYXNzaXN0Ijo0MDAsInNwZWNpYWwiOjUwMCwicGFzc2l2ZWEiOjMwMCwicGFzc2l2ZWIiOjMwMCwicGFzc2l2ZWMiOjMwMCwic2FjcmVkc2VhbCI6MzAwLCJwYXNzaXZleCI6MH0sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjEwLCJib29uIjoic3BkIiwiYmFuZSI6bnVsbCwiYmxlc3NpbmciOiJFYXJ0aCIsImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH0seyJpZCI6IlBJRF/jgrDjg63jg7zjg6Hjg6siLCJza2lsbElkcyI6eyJ3ZWFwb24iOiJTSURf44Oc44Or44OI44Ki44Kv44K5IiwiYXNzaXN0IjoiU0lEX+aUu+aSg+WuiOWCmeOBruW/nOaPtO+8iyIsInNwZWNpYWwiOiJTSURf6KeS6YCQIiwicGFzc2l2ZWEiOiJTSURf6ay856We6aOb54eV44Gu54KO5pKDMyIsInBhc3NpdmViIjoiU0lEX+WkqeiInuOBhOeri+OBpCIsInBhc3NpdmVjIjoiU0lEX+aUu+aSg+mAn+OBleOBruS/oee+qTQiLCJzYWNyZWRzZWFsIjoiU1NJRF/pgaDlj43jg7vliaPmp43mlqflsILnlKgifSwic2tpbGxTUHMiOnsid2VhcG9uIjo0MDAsImFzc2lzdCI6NDAwLCJzcGVjaWFsIjo1MDAsInBhc3NpdmVhIjozMDAsInBhc3NpdmViIjo0MDAsInBhc3NpdmVjIjozMDAsInNhY3JlZHNlYWwiOjMwMCwicGFzc2l2ZXgiOjB9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjoxMCwiYm9vbiI6bnVsbCwiYmFuZSI6bnVsbCwiYmxlc3NpbmciOiJFYXJ0aCIsImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH1d',
   context: {
-    hasBonusUnit: true,
-    seasonElements: [ELEMENT_WATER, ELEMENT_EARTH],
+    mode: MODE_ARENA,
+    arena: {
+      hasBonusUnit: true,
+      seasons: [ELEMENT_WATER, ELEMENT_EARTH],
+    },
   },
   expectedVisibleFinalScores: [744, 774, 760, 776],
   expectedTeamFinalScore: 762,
@@ -202,8 +237,11 @@ const TEAM_MYTHIC_IN_SEASON_2_DUOS: TeamCase = {
   name: 'in-season mythic (M!Embla) blessing bonus: 2 duo teammates',
   code: 'SCTv1:W3siaWQiOiJQSURf5Lyd5om/44Kr44Of44OpIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoiaHAiLCJiYW5lIjoiYXRrIiwiYmxlc3NpbmciOiJXYXRlciIsInNraWxsU1BzIjp7fSwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfSx7ImlkIjoiUElEX+OCqOODs+ODluODqeWRs+aWuSIsInNraWxsSWRzIjp7fSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6MCwiYm9vbiI6bnVsbCwiYmFuZSI6bnVsbCwiYmxlc3NpbmciOiJEYXJrIiwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9LHsiaWQiOiJQSURf5q+U57+844K344Oj44Ot44OzIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoic3BkIiwiYmFuZSI6ImF0ayIsImJsZXNzaW5nIjpudWxsLCJza2lsbFNQcyI6e30sImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH0seyJpZCI6IlBJRF/mr5Tnv7zjg5TjgqLjg4vjg7wiLCJza2lsbElkcyI6e30sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjAsImJvb24iOiJyZXMiLCJiYW5lIjoiaHAiLCJibGVzc2luZyI6bnVsbCwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9XQ==',
   context: {
-    hasBonusUnit: true,
-    seasonElements: [ELEMENT_WATER, ELEMENT_WIND, ELEMENT_LIGHT, ELEMENT_DARK],
+    mode: MODE_ARENA,
+    arena: {
+      hasBonusUnit: true,
+      seasons: [ELEMENT_WATER, ELEMENT_WIND, ELEMENT_LIGHT, ELEMENT_DARK],
+    },
   },
   expectedVisibleFinalScores: [676, 676, 678, 672],
   expectedTeamFinalScore: 674,
@@ -213,8 +251,11 @@ const TEAM_MYTHIC_IN_SEASON_PLUS_LEGENDARY_1: TeamCase = {
   name: 'in-season mythic (M!Embla) blessing bonus: + L!Shez',
   code: 'SCTv1:W3siaWQiOiJQSURf5Lyd5om/44Kr44Of44OpIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoiaHAiLCJiYW5lIjoiYXRrIiwiYmxlc3NpbmciOiJXYXRlciIsInNraWxsU1BzIjp7fSwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfSx7ImlkIjoiUElEX+OCqOODs+ODluODqeWRs+aWuSIsInNraWxsSWRzIjp7fSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6MCwiYm9vbiI6bnVsbCwiYmFuZSI6bnVsbCwiYmxlc3NpbmciOiJEYXJrIiwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9LHsiaWQiOiJQSURf5Lyd5om/44K344Kn44K655S3Iiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoiZGVmIiwiYmFuZSI6ImhwIiwiYmxlc3NpbmciOiJXaW5kIiwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9LHsiaWQiOiJQSURf5q+U57+844OU44Ki44OL44O8Iiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoicmVzIiwiYmFuZSI6ImhwIiwiYmxlc3NpbmciOm51bGwsInNraWxsU1BzIjp7fSwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfV0=',
   context: {
-    hasBonusUnit: true,
-    seasonElements: [ELEMENT_WATER, ELEMENT_WIND, ELEMENT_LIGHT, ELEMENT_DARK],
+    mode: MODE_ARENA,
+    arena: {
+      hasBonusUnit: true,
+      seasons: [ELEMENT_WATER, ELEMENT_WIND, ELEMENT_LIGHT, ELEMENT_DARK],
+    },
   },
   expectedVisibleFinalScores: [676, 684, 678, 672],
   expectedTeamFinalScore: 676,
@@ -224,8 +265,11 @@ const TEAM_MYTHIC_IN_SEASON_PLUS_LEGENDARY_2: TeamCase = {
   name: 'in-season mythic (M!Embla) blessing bonus: + L!Caeda',
   code: 'SCTv1:W3siaWQiOiJQSURf5Lyd5om/44Kr44Of44OpIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoiaHAiLCJiYW5lIjoiYXRrIiwiYmxlc3NpbmciOiJXYXRlciIsInNraWxsU1BzIjp7fSwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfSx7ImlkIjoiUElEX+OCqOODs+ODluODqeWRs+aWuSIsInNraWxsSWRzIjp7fSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6MCwiYm9vbiI6bnVsbCwiYmFuZSI6bnVsbCwiYmxlc3NpbmciOiJEYXJrIiwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9LHsiaWQiOiJQSURf5q+U57+844K344Oj44Ot44OzIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoic3BkIiwiYmFuZSI6ImF0ayIsImJsZXNzaW5nIjpudWxsLCJza2lsbFNQcyI6e30sImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH0seyJpZCI6IlBJRF/kvJ3mib/jgrfjg7zjg4AiLCJza2lsbElkcyI6e30sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjAsImJvb24iOm51bGwsImJhbmUiOm51bGwsImJsZXNzaW5nIjoiV2F0ZXIiLCJza2lsbFNQcyI6e30sImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH1d',
   context: {
-    hasBonusUnit: true,
-    seasonElements: [ELEMENT_WATER, ELEMENT_WIND, ELEMENT_LIGHT, ELEMENT_DARK],
+    mode: MODE_ARENA,
+    arena: {
+      hasBonusUnit: true,
+      seasons: [ELEMENT_WATER, ELEMENT_WIND, ELEMENT_LIGHT, ELEMENT_DARK],
+    },
   },
   expectedVisibleFinalScores: [676, 684, 678, 672],
   expectedTeamFinalScore: 676,
@@ -236,8 +280,11 @@ const TEAM_MYTHIC_IN_SEASON_PLUS_LEGENDARY_BOTH: TeamCase = {
   name: 'in-season mythic (M!Embla) blessing bonus: + L!Shez + L!Caeda',
   code: 'SCTv1:W3siaWQiOiJQSURf5Lyd5om/44Kr44Of44OpIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoiaHAiLCJiYW5lIjoiYXRrIiwiYmxlc3NpbmciOiJXYXRlciIsInNraWxsU1BzIjp7fSwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfSx7ImlkIjoiUElEX+OCqOODs+ODluODqeWRs+aWuSIsInNraWxsSWRzIjp7fSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6MCwiYm9vbiI6bnVsbCwiYmFuZSI6bnVsbCwiYmxlc3NpbmciOiJEYXJrIiwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9LHsiaWQiOiJQSURf5Lyd5om/44K344Kn44K655S3Iiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoiZGVmIiwiYmFuZSI6ImhwIiwiYmxlc3NpbmciOiJXaW5kIiwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9LHsiaWQiOiJQSURf5Lyd5om/44K344O844OAIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjpudWxsLCJiYW5lIjpudWxsLCJibGVzc2luZyI6IldhdGVyIiwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9XQ==',
   context: {
-    hasBonusUnit: true,
-    seasonElements: [ELEMENT_WATER, ELEMENT_WIND, ELEMENT_LIGHT, ELEMENT_DARK],
+    mode: MODE_ARENA,
+    arena: {
+      hasBonusUnit: true,
+      seasons: [ELEMENT_WATER, ELEMENT_WIND, ELEMENT_LIGHT, ELEMENT_DARK],
+    },
   },
   expectedVisibleFinalScores: [676, 692, 678, 672],
   expectedTeamFinalScore: 678,
@@ -253,8 +300,11 @@ const TEAM_MYTHIC_OUT_OF_SEASON_2_DUOS: TeamCase = {
   name: 'out-of-season mythic (M!Heimdallr) blessing bonus: 2 duo teammates',
   code: 'SCTv1:W3siaWQiOiJQSURf5Lyd5om/44Kr44Of44OpIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoiaHAiLCJiYW5lIjoiYXRrIiwiYmxlc3NpbmciOiJXYXRlciIsInNraWxsU1BzIjp7fSwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfSx7ImlkIjoiUElEX+ODmOOCpOODoOODgOODq+WRs+aWuSIsInNraWxsSWRzIjp7fSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6MCwiYm9vbiI6InJlcyIsImJhbmUiOiJkZWYiLCJibGVzc2luZyI6IkFuaW1hIiwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9LHsiaWQiOiJQSURf5q+U57+844K344Oj44Ot44OzIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoic3BkIiwiYmFuZSI6ImF0ayIsImJsZXNzaW5nIjpudWxsLCJza2lsbFNQcyI6e30sImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH0seyJpZCI6IlBJRF/mr5Tnv7zjg5TjgqLjg4vjg7wiLCJza2lsbElkcyI6e30sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjAsImJvb24iOiJyZXMiLCJiYW5lIjoiaHAiLCJibGVzc2luZyI6bnVsbCwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9XQ==',
   context: {
-    hasBonusUnit: true,
-    seasonElements: [ELEMENT_WATER, ELEMENT_WIND, ELEMENT_LIGHT, ELEMENT_DARK],
+    mode: MODE_ARENA,
+    arena: {
+      hasBonusUnit: true,
+      seasons: [ELEMENT_WATER, ELEMENT_WIND, ELEMENT_LIGHT, ELEMENT_DARK],
+    },
   },
   expectedVisibleFinalScores: [676, 670, 678, 672],
   expectedTeamFinalScore: 674,
@@ -263,8 +313,11 @@ const TEAM_MYTHIC_OUT_OF_SEASON_PLUS_LEGENDARY_1: TeamCase = {
   name: 'out-of-season mythic (M!Heimdallr) blessing bonus: + L!Shez',
   code: 'SCTv1:W3siaWQiOiJQSURf5Lyd5om/44Kr44Of44OpIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoiaHAiLCJiYW5lIjoiYXRrIiwiYmxlc3NpbmciOiJXYXRlciIsInNraWxsU1BzIjp7fSwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfSx7ImlkIjoiUElEX+ODmOOCpOODoOODgOODq+WRs+aWuSIsInNraWxsSWRzIjp7fSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6MCwiYm9vbiI6InJlcyIsImJhbmUiOiJkZWYiLCJibGVzc2luZyI6IkFuaW1hIiwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9LHsiaWQiOiJQSURf5Lyd5om/44K344Kn44K655S3Iiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoiZGVmIiwiYmFuZSI6ImhwIiwiYmxlc3NpbmciOiJXaW5kIiwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9LHsiaWQiOiJQSURf5q+U57+844OU44Ki44OL44O8Iiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoicmVzIiwiYmFuZSI6ImhwIiwiYmxlc3NpbmciOm51bGwsInNraWxsU1BzIjp7fSwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfV0=',
   context: {
-    hasBonusUnit: true,
-    seasonElements: [ELEMENT_WATER, ELEMENT_WIND, ELEMENT_LIGHT, ELEMENT_DARK],
+    mode: MODE_ARENA,
+    arena: {
+      hasBonusUnit: true,
+      seasons: [ELEMENT_WATER, ELEMENT_WIND, ELEMENT_LIGHT, ELEMENT_DARK],
+    },
   },
   expectedVisibleFinalScores: [676, 670, 678, 672],
   expectedTeamFinalScore: 674,
@@ -273,8 +326,11 @@ const TEAM_MYTHIC_OUT_OF_SEASON_PLUS_LEGENDARY_2: TeamCase = {
   name: 'out-of-season mythic (M!Heimdallr) blessing bonus: + L!Caeda',
   code: 'SCTv1:W3siaWQiOiJQSURf5Lyd5om/44Kr44Of44OpIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoiaHAiLCJiYW5lIjoiYXRrIiwiYmxlc3NpbmciOiJXYXRlciIsInNraWxsU1BzIjp7fSwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfSx7ImlkIjoiUElEX+ODmOOCpOODoOODgOODq+WRs+aWuSIsInNraWxsSWRzIjp7fSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6MCwiYm9vbiI6InJlcyIsImJhbmUiOiJkZWYiLCJibGVzc2luZyI6IkFuaW1hIiwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9LHsiaWQiOiJQSURf5q+U57+844K344Oj44Ot44OzIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoic3BkIiwiYmFuZSI6ImF0ayIsImJsZXNzaW5nIjpudWxsLCJza2lsbFNQcyI6e30sImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH0seyJpZCI6IlBJRF/kvJ3mib/jgrfjg7zjg4AiLCJza2lsbElkcyI6e30sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjAsImJvb24iOm51bGwsImJhbmUiOm51bGwsImJsZXNzaW5nIjoiV2F0ZXIiLCJza2lsbFNQcyI6e30sImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH1d',
   context: {
-    hasBonusUnit: true,
-    seasonElements: [ELEMENT_WATER, ELEMENT_WIND, ELEMENT_LIGHT, ELEMENT_DARK],
+    mode: MODE_ARENA,
+    arena: {
+      hasBonusUnit: true,
+      seasons: [ELEMENT_WATER, ELEMENT_WIND, ELEMENT_LIGHT, ELEMENT_DARK],
+    },
   },
   expectedVisibleFinalScores: [676, 670, 678, 672],
   expectedTeamFinalScore: 674,
@@ -283,8 +339,11 @@ const TEAM_MYTHIC_OUT_OF_SEASON_PLUS_LEGENDARY_BOTH: TeamCase = {
   name: 'out-of-season mythic (M!Heimdallr) blessing bonus: + L!Shez + L!Caeda',
   code: 'SCTv1:W3siaWQiOiJQSURf5Lyd5om/44Kr44Of44OpIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoiaHAiLCJiYW5lIjoiYXRrIiwiYmxlc3NpbmciOiJXYXRlciIsInNraWxsU1BzIjp7fSwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfSx7ImlkIjoiUElEX+ODmOOCpOODoOODgOODq+WRs+aWuSIsInNraWxsSWRzIjp7fSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6MCwiYm9vbiI6InJlcyIsImJhbmUiOiJkZWYiLCJibGVzc2luZyI6IkFuaW1hIiwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9LHsiaWQiOiJQSURf5Lyd5om/44K344Kn44K655S3Iiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoiZGVmIiwiYmFuZSI6ImhwIiwiYmxlc3NpbmciOiJXaW5kIiwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9LHsiaWQiOiJQSURf5Lyd5om/44K344O844OAIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjpudWxsLCJiYW5lIjpudWxsLCJibGVzc2luZyI6IldhdGVyIiwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9XQ==',
   context: {
-    hasBonusUnit: true,
-    seasonElements: [ELEMENT_WATER, ELEMENT_WIND, ELEMENT_LIGHT, ELEMENT_DARK],
+    mode: MODE_ARENA,
+    arena: {
+      hasBonusUnit: true,
+      seasons: [ELEMENT_WATER, ELEMENT_WIND, ELEMENT_LIGHT, ELEMENT_DARK],
+    },
   },
   expectedVisibleFinalScores: [676, 670, 678, 672],
   expectedTeamFinalScore: 674,
@@ -302,8 +361,11 @@ const TEAM_MYTHIC_OUT_OF_SEASON_CHOSEN_HERO_IN_SEASON_2_DUOS: TeamCase = {
   name: 'out-of-season mythic (M!Heimdallr) w/ in-season chosen hero (C!Alfonse): 2 duo teammates',
   code: 'SCTv1:W3siaWQiOiJQSURf5Lyd5om/44Kr44Of44OpIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoiaHAiLCJiYW5lIjoiYXRrIiwiYmxlc3NpbmciOiJXYXRlciIsInNraWxsU1BzIjp7fSwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfSx7ImlkIjoiUElEX+ODmOOCpOODoOODgOODq+WRs+aWuSIsInNraWxsSWRzIjp7fSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6MCwiYm9vbiI6InJlcyIsImJhbmUiOiJkZWYiLCJibGVzc2luZyI6IkFuaW1hIiwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOiJQSURf5pWR5LiW44Ki44Or44OV44Kp44Oz44K5IiwiY2hvc2VuSGVyb01lcmdlcyI6NX0seyJpZCI6IlBJRF/mr5Tnv7zjgrfjg6Pjg63jg7MiLCJza2lsbElkcyI6e30sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjAsImJvb24iOiJzcGQiLCJiYW5lIjoiYXRrIiwiYmxlc3NpbmciOm51bGwsInNraWxsU1BzIjp7fSwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfSx7ImlkIjoiUElEX+avlOe/vOODlOOCouODi+ODvCIsInNraWxsSWRzIjp7fSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6MCwiYm9vbiI6InJlcyIsImJhbmUiOiJocCIsImJsZXNzaW5nIjpudWxsLCJza2lsbFNQcyI6e30sImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH1d',
   context: {
-    hasBonusUnit: true,
-    seasonElements: [ELEMENT_WATER, ELEMENT_WIND, ELEMENT_LIGHT, ELEMENT_DARK],
+    mode: MODE_ARENA,
+    arena: {
+      hasBonusUnit: true,
+      seasons: [ELEMENT_WATER, ELEMENT_WIND, ELEMENT_LIGHT, ELEMENT_DARK],
+    },
   },
   expectedVisibleFinalScores: [676, 756, 678, 672],
   expectedTeamFinalScore: 694,
@@ -315,13 +377,11 @@ const TEAM_MYTHIC_OUT_OF_SEASON_CHOSEN_HERO_IN_SEASON_PLUS_LEGENDARY_1: TeamCase
     name: 'out-of-season mythic (M!Heimdallr) w/ in-season chosen hero (C!Alfonse): + L!Shez',
     code: 'SCTv1:W3siaWQiOiJQSURf5Lyd5om/44Kr44Of44OpIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoiaHAiLCJiYW5lIjoiYXRrIiwiYmxlc3NpbmciOiJXYXRlciIsInNraWxsU1BzIjp7fSwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfSx7ImlkIjoiUElEX+ODmOOCpOODoOODgOODq+WRs+aWuSIsInNraWxsSWRzIjp7fSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6MCwiYm9vbiI6InJlcyIsImJhbmUiOiJkZWYiLCJibGVzc2luZyI6IkFuaW1hIiwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOiJQSURf5pWR5LiW44Ki44Or44OV44Kp44Oz44K5IiwiY2hvc2VuSGVyb01lcmdlcyI6NX0seyJpZCI6IlBJRF/kvJ3mib/jgrfjgqfjgrrnlLciLCJza2lsbElkcyI6e30sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjAsImJvb24iOiJkZWYiLCJiYW5lIjoiaHAiLCJibGVzc2luZyI6IldpbmQiLCJza2lsbFNQcyI6e30sImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH0seyJpZCI6IlBJRF/mr5Tnv7zjg5TjgqLjg4vjg7wiLCJza2lsbElkcyI6e30sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjAsImJvb24iOiJyZXMiLCJiYW5lIjoiaHAiLCJibGVzc2luZyI6bnVsbCwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9XQ==',
     context: {
-      hasBonusUnit: true,
-      seasonElements: [
-        ELEMENT_WATER,
-        ELEMENT_WIND,
-        ELEMENT_LIGHT,
-        ELEMENT_DARK,
-      ],
+      mode: MODE_ARENA,
+      arena: {
+        hasBonusUnit: true,
+        seasons: [ELEMENT_WATER, ELEMENT_WIND, ELEMENT_LIGHT, ELEMENT_DARK],
+      },
     },
     expectedVisibleFinalScores: [676, 764, 678, 672],
     expectedTeamFinalScore: 696,
@@ -333,13 +393,11 @@ const TEAM_MYTHIC_OUT_OF_SEASON_CHOSEN_HERO_IN_SEASON_PLUS_LEGENDARY_2: TeamCase
     name: 'out-of-season mythic (M!Heimdallr) w/ in-season chosen hero (C!Alfonse): + L!Caeda',
     code: 'SCTv1:W3siaWQiOiJQSURf5Lyd5om/44Kr44Of44OpIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoiaHAiLCJiYW5lIjoiYXRrIiwiYmxlc3NpbmciOiJXYXRlciIsInNraWxsU1BzIjp7fSwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfSx7ImlkIjoiUElEX+ODmOOCpOODoOODgOODq+WRs+aWuSIsInNraWxsSWRzIjp7fSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6MCwiYm9vbiI6InJlcyIsImJhbmUiOiJkZWYiLCJibGVzc2luZyI6IkFuaW1hIiwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOiJQSURf5pWR5LiW44Ki44Or44OV44Kp44Oz44K5IiwiY2hvc2VuSGVyb01lcmdlcyI6NX0seyJpZCI6IlBJRF/mr5Tnv7zjgrfjg6Pjg63jg7MiLCJza2lsbElkcyI6e30sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjAsImJvb24iOiJzcGQiLCJiYW5lIjoiYXRrIiwiYmxlc3NpbmciOm51bGwsInNraWxsU1BzIjp7fSwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfSx7ImlkIjoiUElEX+S8neaJv+OCt+ODvOODgCIsInNraWxsSWRzIjp7fSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6MCwiYm9vbiI6bnVsbCwiYmFuZSI6bnVsbCwiYmxlc3NpbmciOiJXYXRlciIsInNraWxsU1BzIjp7fSwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfV0=',
     context: {
-      hasBonusUnit: true,
-      seasonElements: [
-        ELEMENT_WATER,
-        ELEMENT_WIND,
-        ELEMENT_LIGHT,
-        ELEMENT_DARK,
-      ],
+      mode: MODE_ARENA,
+      arena: {
+        hasBonusUnit: true,
+        seasons: [ELEMENT_WATER, ELEMENT_WIND, ELEMENT_LIGHT, ELEMENT_DARK],
+      },
     },
     expectedVisibleFinalScores: [676, 756, 678, 672],
     expectedTeamFinalScore: 694,
@@ -351,13 +409,11 @@ const TEAM_MYTHIC_OUT_OF_SEASON_CHOSEN_HERO_IN_SEASON_PLUS_LEGENDARY_BOTH: TeamC
     name: 'out-of-season mythic (M!Heimdallr) w/ in-season chosen hero (C!Alfonse): + L!Shez + L!Caeda',
     code: 'SCTv1:W3siaWQiOiJQSURf5Lyd5om/44Kr44Of44OpIiwic2tpbGxJZHMiOnt9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjowLCJib29uIjoiaHAiLCJiYW5lIjoiYXRrIiwiYmxlc3NpbmciOiJXYXRlciIsInNraWxsU1BzIjp7fSwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfSx7ImlkIjoiUElEX+ODmOOCpOODoOODgOODq+WRs+aWuSIsInNraWxsSWRzIjp7fSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6MCwiYm9vbiI6InJlcyIsImJhbmUiOiJkZWYiLCJibGVzc2luZyI6IkFuaW1hIiwic2tpbGxTUHMiOnt9LCJjaG9zZW5IZXJvSWQiOiJQSURf5pWR5LiW44Ki44Or44OV44Kp44Oz44K5IiwiY2hvc2VuSGVyb01lcmdlcyI6NX0seyJpZCI6IlBJRF/kvJ3mib/jgrfjgqfjgrrnlLciLCJza2lsbElkcyI6e30sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjAsImJvb24iOiJkZWYiLCJiYW5lIjoiaHAiLCJibGVzc2luZyI6IldpbmQiLCJza2lsbFNQcyI6e30sImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH0seyJpZCI6IlBJRF/kvJ3mib/jgrfjg7zjg4AiLCJza2lsbElkcyI6e30sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjAsImJvb24iOm51bGwsImJhbmUiOm51bGwsImJsZXNzaW5nIjoiV2F0ZXIiLCJza2lsbFNQcyI6e30sImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH1d',
     context: {
-      hasBonusUnit: true,
-      seasonElements: [
-        ELEMENT_WATER,
-        ELEMENT_WIND,
-        ELEMENT_LIGHT,
-        ELEMENT_DARK,
-      ],
+      mode: MODE_ARENA,
+      arena: {
+        hasBonusUnit: true,
+        seasons: [ELEMENT_WATER, ELEMENT_WIND, ELEMENT_LIGHT, ELEMENT_DARK],
+      },
     },
     expectedVisibleFinalScores: [676, 764, 678, 672],
     expectedTeamFinalScore: 696,
@@ -374,8 +430,7 @@ const TEAM_MJOLNIR_SEIDR: TeamCase = {
   name: "Mjölnir's Strike (dark, tier 20): M!Seidr",
   code: 'SCTv1:W3siaWQiOiJQSURf5q+U57+844Or44Kt44OKIiwic2tpbGxJZHMiOnsid2VhcG9uIjoiU0lEX+iBlueOi+WbveOBrueItuWomOOBruelnuW8kyIsImFzc2lzdCI6IlNJRF/mnKrmnaXjgpLlj7bjgYjjgovnnrMiLCJzYWNyZWRzZWFsIjoiU1NJRF/ov5Hlj43jg7vlvJPmmpflsILnlKgifSwic2tpbGxTUHMiOnsid2VhcG9uIjo0MDAsImFzc2lzdCI6NDAwLCJzcGVjaWFsIjo1MDAsInBhc3NpdmVhIjozMDAsInBhc3NpdmViIjozMDAsInBhc3NpdmVjIjozMDAsInNhY3JlZHNlYWwiOjMwMCwicGFzc2l2ZXgiOjB9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjoxMCwiYm9vbiI6InNwZCIsImJhbmUiOm51bGwsImJsZXNzaW5nIjoiV2F0ZXIiLCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9LHsiaWQiOiJQSURf44Ku44Og44Os44O855S3Iiwic2tpbGxJZHMiOnsic2FjcmVkc2VhbCI6IlNTSURf6YGg5Y+N44O756uc5bCC55SoIn0sInNraWxsU1BzIjp7IndlYXBvbiI6MzUwLCJhc3Npc3QiOjQwMCwic3BlY2lhbCI6NTAwLCJwYXNzaXZlYSI6MzAwLCJwYXNzaXZlYiI6NDAwLCJwYXNzaXZlYyI6MzAwLCJzYWNyZWRzZWFsIjozMDAsInBhc3NpdmV4IjowfSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6MTAsImJvb24iOiJhdGsiLCJiYW5lIjpudWxsLCJibGVzc2luZyI6IldhdGVyIiwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfSx7ImlkIjoiUElEX+ODqeODleOCoeOCqOODqyIsInNraWxsSWRzIjp7InNhY3JlZHNlYWwiOiJTU0lEX+mBoOWPjeODu+WJo+anjeaWp+WwgueUqCJ9LCJza2lsbFNQcyI6eyJ3ZWFwb24iOjM1MCwiYXNzaXN0Ijo0MDAsInNwZWNpYWwiOjUwMCwicGFzc2l2ZWEiOjMwMCwicGFzc2l2ZWIiOjQwMCwicGFzc2l2ZWMiOjMwMCwic2FjcmVkc2VhbCI6MzAwLCJwYXNzaXZleCI6MH0sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjEwLCJib29uIjoiYXRrIiwiYmFuZSI6bnVsbCwiYmxlc3NpbmciOiJXYXRlciIsImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH0seyJpZCI6IlBJRF/jgrvjgqTjgroiLCJza2lsbElkcyI6eyJwYXNzaXZlYSI6IlNJRF/mmI7pj6HmraLmsLQiLCJwYXNzaXZlYyI6IlNJRF/lhbHjgavmnKrmnaXjgpLopovigKbjg7vnpZ4iLCJzYWNyZWRzZWFsIjoiU1NJRF/mraLmsLQzIn0sInNraWxsU1BzIjp7IndlYXBvbiI6NDAwLCJhc3Npc3QiOjQwMCwic3BlY2lhbCI6NTAwLCJwYXNzaXZlYSI6MzAwLCJwYXNzaXZlYiI6NDAwLCJwYXNzaXZlYyI6MzAwLCJzYWNyZWRzZWFsIjoyMDAsInBhc3NpdmV4IjowfSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6NywiYm9vbiI6InJlcyIsImJhbmUiOm51bGwsImJsZXNzaW5nIjoiQXN0cmEiLCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9XQ==',
   context: {
-    hasBonusUnit: false,
-    seasonElements: [],
+    mode: MODE_MJOLNIR_STRIKE,
     mjolnirStrike: { major: ELEMENT_DARK, tier: 20 },
   },
   expectedVisibleFinalScores: [772, 770, 772, 742],
@@ -387,8 +442,7 @@ const TEAM_MJOLNIR_PEONY: TeamCase = {
   name: "Mjölnir's Strike (dark, tier 20): M!Peony",
   code: 'SCTv1:W3siaWQiOiJQSURf5q+U57+844Or44Kt44OKIiwic2tpbGxJZHMiOnsid2VhcG9uIjoiU0lEX+iBlueOi+WbveOBrueItuWomOOBruelnuW8kyIsImFzc2lzdCI6IlNJRF/mnKrmnaXjgpLlj7bjgYjjgovnnrMiLCJzYWNyZWRzZWFsIjoiU1NJRF/ov5Hlj43jg7vlvJPmmpflsILnlKgifSwic2tpbGxTUHMiOnsid2VhcG9uIjo0MDAsImFzc2lzdCI6NDAwLCJzcGVjaWFsIjo1MDAsInBhc3NpdmVhIjozMDAsInBhc3NpdmViIjozMDAsInBhc3NpdmVjIjozMDAsInNhY3JlZHNlYWwiOjMwMCwicGFzc2l2ZXgiOjB9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjoxMCwiYm9vbiI6InNwZCIsImJhbmUiOm51bGwsImJsZXNzaW5nIjoiV2F0ZXIiLCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9LHsiaWQiOiJQSURf44Ku44Og44Os44O855S3Iiwic2tpbGxJZHMiOnsic2FjcmVkc2VhbCI6IlNTSURf6YGg5Y+N44O756uc5bCC55SoIn0sInNraWxsU1BzIjp7IndlYXBvbiI6MzUwLCJhc3Npc3QiOjQwMCwic3BlY2lhbCI6NTAwLCJwYXNzaXZlYSI6MzAwLCJwYXNzaXZlYiI6NDAwLCJwYXNzaXZlYyI6MzAwLCJzYWNyZWRzZWFsIjozMDAsInBhc3NpdmV4IjowfSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6MTAsImJvb24iOiJhdGsiLCJiYW5lIjpudWxsLCJibGVzc2luZyI6IldhdGVyIiwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfSx7ImlkIjoiUElEX+ODqeODleOCoeOCqOODqyIsInNraWxsSWRzIjp7InNhY3JlZHNlYWwiOiJTU0lEX+mBoOWPjeODu+WJo+anjeaWp+WwgueUqCJ9LCJza2lsbFNQcyI6eyJ3ZWFwb24iOjM1MCwiYXNzaXN0Ijo0MDAsInNwZWNpYWwiOjUwMCwicGFzc2l2ZWEiOjMwMCwicGFzc2l2ZWIiOjQwMCwicGFzc2l2ZWMiOjMwMCwic2FjcmVkc2VhbCI6MzAwLCJwYXNzaXZleCI6MH0sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjEwLCJib29uIjoiYXRrIiwiYmFuZSI6bnVsbCwiYmxlc3NpbmciOiJXYXRlciIsImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH0seyJpZCI6IlBJRF/npZ7pmo7jg5TjgqLjg4vjg7wiLCJza2lsbElkcyI6eyJwYXNzaXZlYSI6IlNJRF/pnZLjga7mrbvpl5jjg7vpo5vooYw0IiwicGFzc2l2ZWIiOiJTSURf6a2U44Gu6JuH5q+S44O75ZG85ZC4Iiwic2FjcmVkc2VhbCI6IlNTSURf5puy5oqA6aOb6KGMMyJ9LCJza2lsbFNQcyI6eyJ3ZWFwb24iOjQwMCwiYXNzaXN0Ijo0MDAsInNwZWNpYWwiOjUwMCwicGFzc2l2ZWEiOjMwMCwicGFzc2l2ZWIiOjQwMCwicGFzc2l2ZWMiOjMwMCwic2FjcmVkc2VhbCI6MjQwLCJwYXNzaXZleCI6MH0sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjcsImJvb24iOiJzcGQiLCJiYW5lIjpudWxsLCJibGVzc2luZyI6IkxpZ2h0IiwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfV0=',
   context: {
-    hasBonusUnit: false,
-    seasonElements: [],
+    mode: MODE_MJOLNIR_STRIKE,
     mjolnirStrike: { major: ELEMENT_DARK, tier: 20 },
   },
   expectedVisibleFinalScores: [772, 770, 772, 764],
@@ -402,8 +456,11 @@ const TEAM_MJOLNIR_AYRA: TeamCase = {
   name: "Mjölnir's Strike (dark, tier 20): L!Ayra, water season in arena",
   code: 'SCTv1:W3siaWQiOiJQSURf5q+U57+844Or44Kt44OKIiwic2tpbGxJZHMiOnsid2VhcG9uIjoiU0lEX+iBlueOi+WbveOBrueItuWomOOBruelnuW8kyIsImFzc2lzdCI6IlNJRF/mnKrmnaXjgpLlj7bjgYjjgovnnrMiLCJzYWNyZWRzZWFsIjoiU1NJRF/ov5Hlj43jg7vlvJPmmpflsILnlKgifSwic2tpbGxTUHMiOnsid2VhcG9uIjo0MDAsImFzc2lzdCI6NDAwLCJzcGVjaWFsIjo1MDAsInBhc3NpdmVhIjozMDAsInBhc3NpdmViIjozMDAsInBhc3NpdmVjIjozMDAsInNhY3JlZHNlYWwiOjMwMCwicGFzc2l2ZXgiOjB9LCJsZXZlbCI6NDAsInJhcml0eSI6NSwibWVyZ2VzIjoxMCwiYm9vbiI6InNwZCIsImJhbmUiOm51bGwsImJsZXNzaW5nIjoiV2F0ZXIiLCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9LHsiaWQiOiJQSURf44Ku44Og44Os44O855S3Iiwic2tpbGxJZHMiOnsic2FjcmVkc2VhbCI6IlNTSURf6YGg5Y+N44O756uc5bCC55SoIn0sInNraWxsU1BzIjp7IndlYXBvbiI6MzUwLCJhc3Npc3QiOjQwMCwic3BlY2lhbCI6NTAwLCJwYXNzaXZlYSI6MzAwLCJwYXNzaXZlYiI6NDAwLCJwYXNzaXZlYyI6MzAwLCJzYWNyZWRzZWFsIjozMDAsInBhc3NpdmV4IjowfSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6MTAsImJvb24iOiJhdGsiLCJiYW5lIjpudWxsLCJibGVzc2luZyI6IldhdGVyIiwiY2hvc2VuSGVyb0lkIjpudWxsLCJjaG9zZW5IZXJvTWVyZ2VzIjowfSx7ImlkIjoiUElEX+ODqeODleOCoeOCqOODqyIsInNraWxsSWRzIjp7InNhY3JlZHNlYWwiOiJTU0lEX+mBoOWPjeODu+WJo+anjeaWp+WwgueUqCJ9LCJza2lsbFNQcyI6eyJ3ZWFwb24iOjM1MCwiYXNzaXN0Ijo0MDAsInNwZWNpYWwiOjUwMCwicGFzc2l2ZWEiOjMwMCwicGFzc2l2ZWIiOjQwMCwicGFzc2l2ZWMiOjMwMCwic2FjcmVkc2VhbCI6MzAwLCJwYXNzaXZleCI6MH0sImxldmVsIjo0MCwicmFyaXR5Ijo1LCJtZXJnZXMiOjEwLCJib29uIjoiYXRrIiwiYmFuZSI6bnVsbCwiYmxlc3NpbmciOiJXYXRlciIsImNob3Nlbkhlcm9JZCI6bnVsbCwiY2hvc2VuSGVyb01lcmdlcyI6MH0seyJpZCI6IlBJRF/kvJ3mib/jgqLjgqTjg6kiLCJza2lsbElkcyI6eyJ3ZWFwb24iOiJTSURf44Kk44K244O844Kv44Gu5a6I6K235YmjIiwic3BlY2lhbCI6IlNJRF/liaPogZbjga7mtYHmmJ/pm6gifSwic2tpbGxTUHMiOnsid2VhcG9uIjo0MDAsImFzc2lzdCI6NDAwLCJzcGVjaWFsIjo1MDAsInBhc3NpdmVhIjozMDAsInBhc3NpdmViIjo0MDAsInBhc3NpdmVjIjozMDAsInBhc3NpdmV4IjowfSwibGV2ZWwiOjQwLCJyYXJpdHkiOjUsIm1lcmdlcyI6OCwiYm9vbiI6InNwZCIsImJhbmUiOm51bGwsImJsZXNzaW5nIjoiV2F0ZXIiLCJjaG9zZW5IZXJvSWQiOm51bGwsImNob3Nlbkhlcm9NZXJnZXMiOjB9XQ==',
   context: {
-    hasBonusUnit: false,
-    seasonElements: [ELEMENT_WATER],
+    mode: MODE_MJOLNIR_STRIKE,
+    arena: {
+      hasBonusUnit: false,
+      seasons: [ELEMENT_WATER],
+    },
     mjolnirStrike: { major: ELEMENT_DARK, tier: 20 },
   },
   expectedVisibleFinalScores: [772, 770, 772, 756],
@@ -449,20 +506,21 @@ describe('useUnitScore', () => {
     'computes the expected visibleFinalScore for: $name',
     ({ code, context, expectedVisibleFinalScores, expectedTeamFinalScore }) => {
       const units = decodeTeamInScoreCalc(code)
-      // mirrors pages/score-calc.vue's own mjolnirStrike computed, which
-      // fills in `minor` from `major` via mythicComplement()
-      const mjolnirStrike = context.mjolnirStrike
-        ? ref({
-            isActive: true,
-            major: context.mjolnirStrike.major,
-            minor: mythicComplement(context.mjolnirStrike.major),
-          })
-        : undefined
       const scoreContext = useScoreContext(
         ref(units),
-        ref(context.hasBonusUnit),
-        ref(context.seasonElements),
-        mjolnirStrike,
+        context.arena
+          ? ref({
+              ...context.arena,
+              isActive: context.mode === MODE_ARENA,
+            })
+          : undefined,
+        context.mjolnirStrike
+          ? ref({
+              ...context.mjolnirStrike,
+              isActive: context.mode === MODE_MJOLNIR_STRIKE,
+              minor: mythicComplement(context.mjolnirStrike.major),
+            })
+          : undefined,
       )
 
       const scores: number[] = []

--- a/utils/types/mjolnir-strike.ts
+++ b/utils/types/mjolnir-strike.ts
@@ -1,4 +1,4 @@
-export const MIN_TIER = 0
+export const MIN_TIER = 1
 export const MAX_TIER = 21
 
 // https://www.reddit.com/r/FireEmblemHeroes/comments/eswpa6/comment/fjkg048/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button

--- a/utils/types/score-calc.ts
+++ b/utils/types/score-calc.ts
@@ -10,6 +10,7 @@ import type {
   Element,
   ElementLegendary,
   ElementMythic,
+  ElementOrChaos,
 } from '~/utils/types/elements'
 import type { Stat } from '~/utils/types/units-stats'
 import { WEAPON_R, WEAPON_B, WEAPON_G, WEAPON_C } from '~/utils/types/weapons'
@@ -37,12 +38,34 @@ export interface IUnitInstanceInScoreCalcV2 extends IUnitInstanceInScoreCalcV1 {
 }
 export type IUnitInstanceInScoreCalc = IUnitInstanceInScoreCalcV2
 
-export interface ScoreContext {
-  bonusFactor: number
-  seasonElements: Element[]
-  legendaryCounts: IndexedBy<ElementLegendary, number>
+export const MODE_ARENA = 'ARENA'
+export const MODE_MJOLNIR_STRIKE = 'MJOLNIR_STRIKE'
+export type Mode = typeof MODE_ARENA | typeof MODE_MJOLNIR_STRIKE
+
+export interface ScoreContextIn {
+  arena: {
+    isActive: boolean
+    hasBonusUnit: boolean
+    seasons: ElementOrChaos[]
+  }
   mjolnirStrike: {
     isActive: boolean
+    tier: number | null
+    major: ElementMythic | null
+    minor: ElementMythic | null
+  }
+}
+export interface ScoreContextOut {
+  bonusFactor: number
+  arena: {
+    isActive: boolean
+    hasBonusUnit: boolean
+    seasons: ElementOrChaos[]
+    legendaryCounts: IndexedBy<ElementLegendary, number>
+  }
+  mjolnirStrike: {
+    isActive: boolean
+    tier: number | null
     major: ElementMythic | null
     minor: ElementMythic | null
   }


### PR DESCRIPTION
- pages/score-calc.vue: replace isMjolnirStrike boolean with mode (MODE_ARENA/MODE_MJOLNIR_STRIKE); rename hasBonusUnit/seasonElements to arenaHasBonusUnit/arenaSeasons; pass an arena hash to useScoreContext instead of separate refs
- useScoreContext: accept ScoreContextIn (arena/mjolnirStrike) and return ScoreContextOut, nesting seasons/legendaryCounts under arena
- useUnitScore: read season/legendary data from scoreContext.arena
- bump local-storage/save-file payload to v4, storing mode/arenaHasBonusUnit/arenaSeasons directly; v1-v3 still parsed and migrated into the new shape
- update useUnitScore.test.ts TeamCase fixtures and useScoreContext test call sites to the new mode/arena/mjolnirStrike context shape