### PR TITLE
feat: sort banners chronologically by release date in name

### DIFF
--- a/pages/catalog-of-heroes.vue
+++ b/pages/catalog-of-heroes.vue
@@ -276,7 +276,7 @@
           <AppAutocomplete
             v-model="storeDataBanners.selectedBanner"
             :loading="storeDataBanners.isLoading"
-            :items="storeDataBanners.banners || []"
+            :items="storeDataBanners.banners"
             item-title="name"
             item-value="name"
             clearable

--- a/stores/data/banners.ts
+++ b/stores/data/banners.ts
@@ -2,21 +2,35 @@ import sortBy from 'lodash-es/sortBy'
 
 import type { UnitId } from '~/utils/types/units'
 import { chunkMaxLength } from '~/utils/functions/typeSafe'
+import { getSortableName } from '~/utils/functions/bannerSortingVector'
 
-interface IBanner {
+interface IBannerData {
   name: string
   unit_ids: UnitId[]
+}
+interface IBanner extends IBannerData {
+  nameForSorting: string
 }
 
 export const useStoreDataBanners = defineStore('data/banners', () => {
   const storeDataUnits = useStoreDataUnits()
 
-  const banners = ref<IBanner[]>()
+  const bannersData = ref<IBannerData[]>([])
 
   const { isLoading, isLoaded, load } = useData(
     'banners.json',
     'stores/data/banners/load',
-    banners,
+    bannersData,
+  )
+
+  const banners = computed<IBanner[]>(() =>
+    sortBy(
+      bannersData.value.map((banner) => ({
+        ...banner,
+        nameForSorting: getSortableName(banner.name),
+      })),
+      'nameForSorting',
+    ),
   )
 
   const selectedBanner = ref<IBanner>()

--- a/utils/functions/bannerSortingVector.ts
+++ b/utils/functions/bannerSortingVector.ts
@@ -1,0 +1,22 @@
+const SORTABLE_NAME_MONTHS: Record<string, string> = {
+  Jan: '01',
+  Feb: '02',
+  Mar: '03',
+  Apr: '04',
+  May: '05',
+  Jun: '06',
+  Jul: '07',
+  Aug: '08',
+  Sep: '09',
+  Oct: '10',
+  Nov: '11',
+  Dec: '12',
+}
+
+export function getSortableName(name: string) {
+  return name.replace(
+    /\b(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{4})\b/g,
+    (_match, month: string, year: string) =>
+      `${year}-${SORTABLE_NAME_MONTHS[month]}`,
+  )
+}


### PR DESCRIPTION
Banner names embed a release date like "(Apr 2024)", but the autocomplete was sorting on the raw name, so months grouped alphabetically (all "Apr" entries before all "Aug" entries) instead of chronologically.

Add getSortableName (bannerSortingVector.ts, same pattern as skillSortingVector.ts) to rewrite "Mon YYYY" to "YYYY-MM", and use it to sort the banners list in the store.